### PR TITLE
Feature: Enable reference style links

### DIFF
--- a/example/src/pages/index.md
+++ b/example/src/pages/index.md
@@ -72,7 +72,9 @@ Try the Analytics API with Swagger UI. Explore, make calls, with full endpoint d
 
 We encourage you to participate in our open documentation initiative, if you have suggestions, corrections, additions
 or deletions for this documentation, check out the source from [this github repo](https://github.com/adobe/gatsby-theme-spectrum-example), and submit a pull
-request with your contribution. For more information, refer to the [contributing page](support/contribute/).
+request with your contribution. For more information, refer to the [contributing page][].
+
+[contributing page]: /support/contribute
 
 ## API Requests & Rate Limits
 

--- a/packages/gatsby-theme-aio/package.json
+++ b/packages/gatsby-theme-aio/package.json
@@ -80,7 +80,7 @@
     "elasticlunr": "^0.9.5",
     "gatsby-plugin-emotion": "^6.0.0",
     "gatsby-plugin-layout": "^2.0.0",
-    "gatsby-plugin-mdx": "^2.0.1",
+    "gatsby-plugin-mdx": "^2.5.0",
     "gatsby-plugin-mdx-embed": "^0.0.19",
     "gatsby-plugin-preact": "^5.0.0",
     "gatsby-plugin-react-helmet": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8149,6 +8149,20 @@ gatsby-core-utils@^2.2.0-next.0:
     tmp "^0.2.1"
     xdg-basedir "^4.0.0"
 
+gatsby-core-utils@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/gatsby-core-utils/-/gatsby-core-utils-2.5.0.tgz#70b3aabf184a39c790e12af8001be4164fd8afa6"
+  integrity sha512-YbKv7FLpeTCts28bv0H2lSuHrKgUxnsC1ZG1PPydOheQgPW9G8pdNlYvwZzGJmmS7rBcC/w859ss90wlvF6GEw==
+  dependencies:
+    ci-info "2.0.0"
+    configstore "^5.0.1"
+    file-type "^16.2.0"
+    fs-extra "^8.1.0"
+    node-object-hash "^2.0.0"
+    proper-lockfile "^4.1.1"
+    tmp "^0.2.1"
+    xdg-basedir "^4.0.0"
+
 gatsby-cypress@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/gatsby-cypress/-/gatsby-cypress-1.1.0.tgz#f96d0a1f1e06515aaa571608f716b01a5de89f16"
@@ -8213,10 +8227,10 @@ gatsby-plugin-mdx-embed@^0.0.19:
   resolved "https://registry.yarnpkg.com/gatsby-plugin-mdx-embed/-/gatsby-plugin-mdx-embed-0.0.19.tgz#1d1a524fd1fc0a359a2dcb045c9c208b4e8142ce"
   integrity sha512-Z+xjcOaStmWaNozgX8zFZMMVvEb/rxKI456XIwxXdyGunuUkYnCKLECyEJ4jLCtHOub/LXb7pMIInEXX8SHAcA==
 
-gatsby-plugin-mdx@^2.0.1:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-mdx/-/gatsby-plugin-mdx-2.1.0.tgz#1ae6d096016d40219fe254a1bf2fe9e7a4ce6e7a"
-  integrity sha512-0iSsPxCUTJMeTbozHVqczlgMAKxZJ4IkxOS5a6aTCwzrOOwIfc5YqcWQEBS3nfUF/azzEIejYuydyTMi68Y76A==
+gatsby-plugin-mdx@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-mdx/-/gatsby-plugin-mdx-2.5.0.tgz#6ffe790f43731dbf1c70369826861936f1d18d12"
+  integrity sha512-q4BrUdMB/OCpLcOxGqbMBl7RhKWc5F5dKThGETaFtROzDLW4Uiw4Mww8tY6oGAgQfyWNl9sh+tadiiM9pbJJXg==
   dependencies:
     "@babel/core" "^7.12.3"
     "@babel/generator" "^7.12.5"
@@ -8233,7 +8247,7 @@ gatsby-plugin-mdx@^2.0.1:
     escape-string-regexp "^1.0.5"
     eval "^0.1.4"
     fs-extra "^8.1.0"
-    gatsby-core-utils "^2.1.0"
+    gatsby-core-utils "^2.5.0"
     gray-matter "^4.0.2"
     json5 "^2.1.3"
     loader-utils "^1.4.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updates the `gatsby-plugin-mdx` dependency to 2.5.0, which contains my reference style link bugfix (https://github.com/gatsbyjs/gatsby/pull/30967).

## Related Issue

Closes #305 

## Motivation and Context

Enables reference-style links for documentation projects that currently or may use it.

## How Has This Been Tested?

1. Converted an inline link in the root `index.md` page into a reference style link.
2. Created a production build with prefix and pointed the HTTP server to the build artifacts: `yarn start:prefix`
3. Navigated to http://localhost:9000/example/ 
4. Verified the **contributing page** link destination contains the `example` base URL

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
