### PR TITLE
Fixed Frontmatter: Added resolvers to extend MdxFrontmatter fields properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .editorconfig
+.DS_STORE
 
 # npm yarn
 node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .editorconfig
-.DS_STORE
 
 # npm yarn
 node_modules

--- a/packages/gatsby-theme-aio/gatsby-node.js
+++ b/packages/gatsby-theme-aio/gatsby-node.js
@@ -105,14 +105,33 @@ exports.createSchemaCustomization = ({ actions }) => {
       path: String
       pages: [Link]
     }
-
-    type MdxFrontmatter {
-      title: String
-      description: String
-      contributors: [String]
-      keywords: [String]
-    }
   `;
 
   createTypes(typeDefs);
+};
+
+exports.createResolvers = ({ createResolvers, addFrontmatterType }) => {
+  const resolvers = {
+    MdxFrontmatter: {
+      keywords: {
+        type: '[String]',
+        resolve: addFrontmatterType
+      },
+      description: {
+        type: 'String',
+        resolve: addFrontmatterType
+      },
+      contributors: {
+        type: '[String]',
+        resolve: addFrontmatterType
+      }
+    }
+  };
+
+  addFrontmatterType = (source, context) =>
+    context.nodeModel.getNodeById({
+      id: source.MdxFrontmatter
+    });
+
+  createResolvers(resolvers);
 };

--- a/packages/gatsby-theme-aio/gatsby-node.js
+++ b/packages/gatsby-theme-aio/gatsby-node.js
@@ -124,6 +124,26 @@ exports.createResolvers = ({ createResolvers, addFrontmatterType }) => {
       contributors: {
         type: '[String]',
         resolve: addFrontmatterType
+      },
+      openAPISpec: {
+        type: 'String',
+        resolve: addFrontmatterType
+      },
+      frameSrc: {
+        type: 'String',
+        resolve: addFrontmatterType
+      },
+      frameHeight: {
+        type: 'String',
+        resolve: addFrontmatterType
+      },
+      layout: {
+        type: 'String',
+        resolve: addFrontmatterType
+      },
+      jsDoc: {
+        type: 'Boolean',
+        resolve: addFrontmatterType
       }
     }
   };

--- a/packages/gatsby-theme-aio/src/components/JsDocParameters/index.js
+++ b/packages/gatsby-theme-aio/src/components/JsDocParameters/index.js
@@ -87,7 +87,7 @@ const JsDocParameters = ({ items }) => {
     let header = '';
     let body = [];
     let id = '';
-    for (let i = 0; i < items.length; i++) {
+    for (let i = 0; i < items?.length; i++) {
       let item = items[i];
       let type = item.props.mdxType;
       if (type === ANCHOR) {


### PR DESCRIPTION
## Description

This PR adds Gatsby `resolvers` in order to fix problems with the GraphQL query we use within the `query-builder.js`.  It also adds Gatsby's helper function `withPrefix` to create a link I can use on the frontend for search results.

### Issue solved

This PR defines the three missing fields we use for our search records: `description`, `contributors`, and `keywords`. These three fields must be defined explicitly because we use them in our search code and we don't want sites failing to build if they don't define one or more of these fields in their frontmatter. 

For example: The `uxp-photoshop` site failed to build when running tests for search indexing because there was not a single entry of the field `keywords` within the frontmatter of any `md` files. So not even the implicit schema contained `keywords`.

The `gatsby-plugin-mdx` plugin defines only one field for the MdxFrontmatter: `title`. See source code here: https://github.com/gatsbyjs/gatsby/blob/f641c5cbda9444cbd29d26f0cb619693d6426119/packages/gatsby-plugin-mdx/gatsby/source-nodes.js#L73

### Technical background

In Gatsby, plugins create GraphQL `nodes` and `fields` explicitly using `createTypes`. But Gatsby also builds `fields` for existing nodes—like `frontmatter`—**implicitly**. This means, that you can randomly add any new fields to the frontmatter you want and Gatsby will add it to your project's schema **implicitly**. And as long as your code is executed AFTER Gatsby creates the implicit schema AND the field you want to use in your code is actually defined somewhere in the content, then it will work.

However, this is risky and requires lots of `undefined` and `null` checks in your code to make sure you bail when nodes or fields haven't been implicitly created. So in our case, for Algolia search integration, we pull data directly from a GraphQL query within `query-builder.js` and expect it to be there. Depending on the data's implicit presence (from the `md` files), if it's not there (and hasn't been defined explicitly) the indexing breaks, which then breaks the build.

As such, it's always a best practice to explicitly define the `nodes` and `fields` your code depends on. And for existing nodes, like `MdxFrontmatter`, you need to use Gatsby `resolvers` to extend them with your own fields. 

## Motivation and Context

Nodes and fields we depend on in our code should be explicitly defined.

## How Has This Been Tested?

1. Removed all the frontmatter for `md` files in the `example/` site to reproduce errors on the missing frontmatter types. 
2. Ran the theme on the `uxp-photoshop` site, which has no `keywords` defined in any of the `md` files, which means the implicit schema did not contain the `keywords` field. 

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
